### PR TITLE
CircleCIでrubocopを実行できるようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: ruby:2.6.1
+        environment:
+          RAILS_ENV: test
+          TEST_DB_HOST: 127.0.0.1
+          TEST_DB_PASSWORD: password
+          CIRCLE_TEST_REPORTS: /tmp/test-results
+          TZ: "/usr/share/zoneinfo/Asia/Tokyo"
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      - image: mysql:5.7
+        environment:
+          MYSQL_ROOT_PASSWORD: password
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+
+      - run:
+          name: Run Rubocop
+          command: .circleci/run-rubocop.sh
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results

--- a/.circleci/run-rubocop.sh
+++ b/.circleci/run-rubocop.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -v
+
+export RUBYOPT=-EUTF-8
+
+bundle exec rubocop

--- a/.circleci/run-rubocop.sh
+++ b/.circleci/run-rubocop.sh
@@ -3,6 +3,18 @@ set -v
 
 export RUBYOPT=-EUTF-8
 
+if [ "${CIRCLE_BRANCH}" != "master" ] && [ "${CIRCLE_BRANCH}" != "develop" ]; then
+  git diff -z --name-only origin/develop \
+   | xargs -0 bundle exec rubocop-select \
+   | xargs bundle exec rubocop \
+       --require rubocop/formatter/checkstyle_formatter \
+       --format RuboCop::Formatter::CheckstyleFormatter \
+   | bundle exec checkstyle_filter-git diff origin/develop \
+   | bundle exec saddler report \
+      --require saddler/reporter/github \
+      --reporter Saddler::Reporter::Github::PullRequestReviewComment
+fi
+
 bundle exec rubocop \
   -r $(bundle show rubocop-junit-formatter)/lib/rubocop/formatter/junit_formatter.rb \
   -c .rubocop.yml \

--- a/.circleci/run-rubocop.sh
+++ b/.circleci/run-rubocop.sh
@@ -3,4 +3,8 @@ set -v
 
 export RUBYOPT=-EUTF-8
 
-bundle exec rubocop
+bundle exec rubocop \
+  -r $(bundle show rubocop-junit-formatter)/lib/rubocop/formatter/junit_formatter.rb \
+  -c .rubocop.yml \
+  --format RuboCop::Formatter::JUnitFormatter \
+  --out $CIRCLE_TEST_REPORTS/rubocop/rubocop.xml

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,12 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'checkstyle_filter-git'
+  gem 'rubocop-checkstyle_formatter'
   gem 'rubocop-junit-formatter'
+  gem 'rubocop-select'
+  gem 'saddler'
+  gem 'saddler-reporter-github'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,3 @@ group :development do
   gem 'spring-commands-rubocop'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'rubocop-junit-formatter'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
+    rubocop-junit-formatter (0.1.4)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     spring (2.0.2)
@@ -161,6 +162,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.2)
   rubocop
+  rubocop-junit-formatter
   spring
   spring-commands-rubocop
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,16 +42,30 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
     bootsnap (1.4.1)
       msgpack (~> 1.0)
     builder (3.2.3)
     byebug (11.0.0)
+    checkstyle_filter-git (1.1.0)
+      git_diff_parser
+      thor
     concurrent-ruby (1.1.4)
     crass (1.0.4)
+    env_branch (1.3.0)
+    env_pull_request (1.1.0)
+      natural_number_string
     erubi (1.8.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
+    git (1.5.0)
+    git_clone_url (2.0.0)
+      uri-ssh_git (>= 2.0)
+    git_diff_parser (2.3.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
@@ -74,15 +88,21 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.2.7)
+    multipart-post (2.0.0)
     mysql2 (0.5.2)
+    natural_number_string (1.0.1)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    nori (2.6.0)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.14.0)
     parser (2.6.0.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     psych (3.1.0)
+    public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.6)
     rack-test (1.1.0)
@@ -125,9 +145,32 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
+    rubocop-checkstyle_formatter (0.4.0)
+      rubocop (>= 0.35.1)
     rubocop-junit-formatter (0.1.4)
+    rubocop-select (2.0.0)
+      rubocop
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
+    saddler (1.0.0)
+      saddler-reporter-text
+      thor
+    saddler-reporter-github (2.0.0)
+      env_pull_request (>= 1.0)
+      git_diff_parser (>= 2.0, < 3.0)
+      octokit
+      saddler-reporter-support (>= 1.0)
+      saddler-reporter-support-git (>= 1.0)
+    saddler-reporter-support (1.0.0)
+      nori
+    saddler-reporter-support-git (2.0.1)
+      env_branch (>= 1.0)
+      git (>= 1.0, < 2.0)
+      git_clone_url (>= 2.0, < 3.0)
+    saddler-reporter-text (1.0.0)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-commands-rubocop (0.2.0)
@@ -147,6 +190,7 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
+    uri-ssh_git (2.0.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -157,12 +201,17 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  checkstyle_filter-git
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
   puma (~> 3.11)
   rails (~> 5.2.2)
   rubocop
+  rubocop-checkstyle_formatter
   rubocop-junit-formatter
+  rubocop-select
+  saddler
+  saddler-reporter-github
   spring
   spring-commands-rubocop
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,7 +164,6 @@ DEPENDENCIES
   spring
   spring-commands-rubocop
   spring-watcher-listen (~> 2.0.0)
-  tzinfo-data
 
 RUBY VERSION
    ruby 2.6.1p33


### PR DESCRIPTION
# 目的
CircleCIでrubocopを実行できるようにする

# やったこと
- .circleci/config.yml
  - version 2
  - ruby version 2.6.1
  - mysql version 5.7
  - bundle installした内容をキャッシュする
  - rubocopを実行
    - CircleCIで実行したrubocopの結果をTest Summeryに表示
    - Rubocopでエラーになった内容をpull requestにコメントする
- Uninstall tzinfo-data

