### PR TITLE
web-consoleを導入する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,4 +48,5 @@ group :development do
   gem 'spring'
   gem 'spring-commands-rubocop'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    bindex (0.5.0)
     bootsnap (1.4.1)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -191,6 +192,11 @@ GEM
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
     uri-ssh_git (2.0.0)
+    web-console (3.7.0)
+      actionview (>= 5.0)
+      activemodel (>= 5.0)
+      bindex (>= 0.4.0)
+      railties (>= 5.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -215,6 +221,7 @@ DEPENDENCIES
   spring
   spring-commands-rubocop
   spring-watcher-listen (~> 2.0.0)
+  web-console
 
 RUBY VERSION
    ruby 2.6.1p33

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,4 +64,7 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # web_consoleを利用できるアクセス元IPアドレスの制限を解除する
+  config.web_console.whitelisted_ips = %w[0.0.0.0/0 ::/0]
 end


### PR DESCRIPTION
# 目的
デバッグを楽にするためにweb-consoleを導入する

# やったこと
- install web-console
- 開発環境の場合は接続元IPに関わらずweb-consoleを利用できるようにする