### PR TITLE
開発環境でキャッシュを利用できるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV LANG=C.UTF-8
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
             mysql-client \
+            redis-tools \
  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /api

--- a/Gemfile
+++ b/Gemfile
@@ -11,12 +11,10 @@ gem 'rails', '~> 5.2.2'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'mysql2', '>= 0.4.4', '< 0.6.0'
 gem 'puma', '~> 3.11'
+gem 'redis', '~> 4.0'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
-
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 4.0'
 
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.1.0)
     rubocop (0.65.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -212,6 +213,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4, < 0.6.0)
   puma (~> 3.11)
   rails (~> 5.2.2)
+  redis (~> 4.0)
   rubocop
   rubocop-checkstyle_formatter
   rubocop-junit-formatter

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,15 +19,17 @@ Rails.application.configure do
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
+
+  config.cache_store = :redis_cache_store, {
+    namespace: Rails.application.class.parent_name.downcase,
+    url: ENV.fetch('CACHE_STORE_URL')
+  }
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local


### PR DESCRIPTION
# 目的
開発環境でキャッシュを利用できるようにする
キャッシュの保存先はredisにする

# やったこと
- Install redis
- 開発環境でキャッシュをredisに保存するように設定
  - アプリケーション名をキャッシュのキーのprefixにする
  - redisの参照先は環境変数で指定できるようにする
- redis-toolsをインストール
