### PR TITLE
sentryを導入する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'mysql2', '>= 0.4.4', '< 0.6.0'
 gem 'puma', '~> 3.11'
 gem 'redis', '~> 4.0'
+gem 'sentry-raven'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,8 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    sentry-raven (2.9.0)
+      faraday (>= 0.7.6, < 1.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-commands-rubocop (0.2.0)
@@ -232,6 +234,7 @@ DEPENDENCIES
   rubocop-select
   saddler
   saddler-reporter-github
+  sentry-raven
   spring
   spring-commands-rubocop
   spring-watcher-listen (~> 2.0.0)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Raven.configure do |config|
+  config.dsn = 'https://c41545140c0a40c180369284ee5bc5b7:eebc867f9ea642c5a5ec1f437c065c27@sentry.io/1411852'
+
+  config.environments = %w[production]
+
+  config.tags = { project: Rails.application.class.parent_name.underscore }
+
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end


### PR DESCRIPTION
# 目的
sentryを導入して例外監視を楽にする

# やったこと
- Install sentry
- sentryの設定ファイルを追加
  - production環境のみ有効
  - アプリケーション名をタグにつける
  - Railsでマスキングしているフィールドはsentryでもマスキングする