### PR TITLE
Rails標準のメッセージを日本語化する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'rails', '~> 5.2.2'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'mysql2', '>= 0.4.4', '< 0.6.0'
 gem 'puma', '~> 3.11'
+gem 'rails-i18n'
 gem 'redis', '~> 4.0'
 gem 'sentry-raven'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.2)
       actionpack (= 5.2.2)
       activesupport (= 5.2.2)
@@ -227,6 +230,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.2)
+  rails-i18n
   redis (~> 4.0)
   rubocop
   rubocop-checkstyle_formatter

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
-  # デフォルト日本語
+  # 日本語のみ有効
+  config.i18n.available_locales = %i[ja]
   config.i18n.default_locale = :ja
 end


### PR DESCRIPTION
# 目的
Rails標準のメッセージを日本語化する
不要な言語ファイル(英語)は読み込まないことでRailsの起動を少しだけ早くする

# やったこと
- install rails-i18n
- 言語ファイルは日本語のみ利用する