### PR TITLE
ngrokを使ってアクセスした場合のBasic認証を設定できるようにする

### DIFF
--- a/config/initializers/basic_auth.rb
+++ b/config/initializers/basic_auth.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CustomAuthBasicMiddelware < Rack::Auth::Basic
+  def call(env)
+    request = Rack::Request.new(env)
+    if /.ngrok.io\z/.match?(request.host)
+      super
+    else
+      @app.call(env)
+    end
+  end
+end
+
+Rails.application.configure do
+  config.middleware.use CustomAuthBasicMiddelware do |username, password|
+    username == ENV['NGROK_BASIC_USER'] && password == ENV['NGROK_BASIC_PASS']
+  end
+end


### PR DESCRIPTION
# 目的
ngrokを使ってアクセスした場合のBasic認証を設定できるようにする

ngrokを使用するとローカルホストを外部に公開することができる
便利ではあるが誰でもアクセスできるようになってしまうためBasic認証をかけるようにする

# ngrokとは
このあたりを読んでください
https://qiita.com/kitaro729/items/44214f9f81d3ebda58bd

# やったこと
- Rack::Auth::Basicを継承
  - *.ngrok.io からアクセスがあった場合のみBasic認証を行うようにする
- middlewareに追加
