### PR TITLE
Ngrokでアクセスした時のBasic認証判定はdevelopmentの場合のみ動作させる

### DIFF
--- a/config/initializers/basic_auth.rb
+++ b/config/initializers/basic_auth.rb
@@ -12,7 +12,9 @@ class CustomAuthBasicMiddelware < Rack::Auth::Basic
 end
 
 Rails.application.configure do
-  config.middleware.use CustomAuthBasicMiddelware do |username, password|
-    username == ENV['NGROK_BASIC_USER'] && password == ENV['NGROK_BASIC_PASS']
+  if Rails.env.development?
+    config.middleware.use CustomAuthBasicMiddelware do |username, password|
+      username == ENV['NGROK_BASIC_USER'] && password == ENV['NGROK_BASIC_PASS']
+    end
   end
 end


### PR DESCRIPTION
# 目的
middlewareを追加すると全てのリクエストに対して処理が行われてしまうため、全体のレスポンスに影響が出てしまう。
Ngrokはdevelopment以外で利用する想定がないため、development以外ではmiddlewareを差し込まないようにする

# やったこと
- Ngrokでアクセスした時のBasic認証判定はdevelopmentの場合のみ動作させる